### PR TITLE
Add Transactions and AI Advisor pages and navigation

### DIFF
--- a/resources/js/components/AppHeader.vue
+++ b/resources/js/components/AppHeader.vue
@@ -12,7 +12,7 @@ import UserMenuContent from '@/components/UserMenuContent.vue';
 import { getInitials } from '@/composables/useInitials';
 import type { BreadcrumbItem, NavItem } from '@/types';
 import { Link, usePage } from '@inertiajs/vue3';
-import { BookOpen, Folder, LayoutGrid, Menu, Search } from 'lucide-vue-next';
+import { LayoutGrid, Menu, Search, FileText, Bot } from 'lucide-vue-next';
 import { computed } from 'vue';
 
 interface Props {
@@ -38,20 +38,19 @@ const mainNavItems: NavItem[] = [
         href: '/dashboard',
         icon: LayoutGrid,
     },
+    {
+        title: 'Transactions',
+        href: '/transactions',
+        icon: FileText,
+    },
+    {
+        title: 'AI Advisor',
+        href: '/advisor',
+        icon: Bot,
+    },
 ];
 
-const rightNavItems: NavItem[] = [
-    {
-        title: 'Repository',
-        href: 'https://github.com/laravel/vue-starter-kit',
-        icon: Folder,
-    },
-    {
-        title: 'Documentation',
-        href: 'https://laravel.com/docs/starter-kits#vue',
-        icon: BookOpen,
-    },
-];
+const rightNavItems: NavItem[] = [];
 </script>
 
 <template>

--- a/resources/js/components/AppSidebar.vue
+++ b/resources/js/components/AppSidebar.vue
@@ -5,7 +5,7 @@ import NavUser from '@/components/NavUser.vue';
 import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
 import { type NavItem } from '@/types';
 import { Link } from '@inertiajs/vue3';
-import { BookOpen, Folder, LayoutGrid } from 'lucide-vue-next';
+import { LayoutGrid, FileText, Bot } from 'lucide-vue-next';
 import AppLogo from './AppLogo.vue';
 
 const mainNavItems: NavItem[] = [
@@ -14,20 +14,19 @@ const mainNavItems: NavItem[] = [
         href: '/dashboard',
         icon: LayoutGrid,
     },
+    {
+        title: 'Transactions',
+        href: '/transactions',
+        icon: FileText,
+    },
+    {
+        title: 'AI Advisor',
+        href: '/advisor',
+        icon: Bot,
+    },
 ];
 
-const footerNavItems: NavItem[] = [
-    {
-        title: 'Github Repo',
-        href: 'https://github.com/laravel/vue-starter-kit',
-        icon: Folder,
-    },
-    {
-        title: 'Documentation',
-        href: 'https://laravel.com/docs/starter-kits#vue',
-        icon: BookOpen,
-    },
-];
+const footerNavItems: NavItem[] = [];
 </script>
 
 <template>

--- a/resources/js/pages/AIAdvisor.vue
+++ b/resources/js/pages/AIAdvisor.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import AppLayout from '@/layouts/AppLayout.vue';
+import { Head } from '@inertiajs/vue3';
+import type { BreadcrumbItem } from '@/types';
+
+const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'AI Advisor', href: '/advisor' },
+];
+</script>
+
+<template>
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <Head title="AI Advisor" />
+        <div class="p-4"></div>
+    </AppLayout>
+</template>

--- a/resources/js/pages/Transactions.vue
+++ b/resources/js/pages/Transactions.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import AppLayout from '@/layouts/AppLayout.vue';
+import { Head } from '@inertiajs/vue3';
+import type { BreadcrumbItem } from '@/types';
+
+const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'Transactions', href: '/transactions' },
+];
+</script>
+
+<template>
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <Head title="Transactions" />
+        <div class="p-4"></div>
+    </AppLayout>
+</template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,5 +11,15 @@ Route::get('dashboard', function () {
     return Inertia::render('Dashboard');
 })->middleware(['auth', 'verified'])->name('dashboard');
 
+Route::middleware(['auth', 'verified'])->group(function () {
+    Route::get('transactions', function () {
+        return Inertia::render('Transactions');
+    })->name('transactions');
+
+    Route::get('advisor', function () {
+        return Inertia::render('AIAdvisor');
+    })->name('advisor');
+});
+
 require __DIR__.'/settings.php';
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## Summary
- add blank pages for Transactions and AI Advisor
- expose new routes
- update sidebar and header navigation
- remove links to Github repo and documentation

## Testing
- `npm run lint` *(fails: eslint not found)*
- `composer test` *(fails: vendor not installed)*
- `composer install` *(fails: network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6884aa9198448320aa0edc19fd37b058