### PR TITLE
Add statement upload feature

### DIFF
--- a/app/Http/Controllers/StatementController.php
+++ b/app/Http/Controllers/StatementController.php
@@ -29,8 +29,11 @@ class StatementController extends Controller
 
         $file = $validated['statement'];
 
-        // Extract text from the PDF. Additional parsing logic can be placed here.
         $text = Pdf::getText($file->getPathname());
+
+
+//        $text = Pdf::ge($file->getPathname());
+        dd($text);
 
         // TODO: Process \$text to create transactions or other records.
 

--- a/app/Http/Controllers/StatementController.php
+++ b/app/Http/Controllers/StatementController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\RedirectResponse;
+use Inertia\Inertia;
+use Inertia\Response;
+use Spatie\PdfToText\Pdf;
+
+class StatementController extends Controller
+{
+    /**
+     * Display the upload statement page.
+     */
+    public function create(): Response
+    {
+        return Inertia::render('UploadStatement');
+    }
+
+    /**
+     * Handle the uploaded statement PDF.
+     */
+    public function store(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'statement' => ['required', 'file', 'mimes:pdf'],
+        ]);
+
+        $file = $validated['statement'];
+
+        // Extract text from the PDF. Additional parsing logic can be placed here.
+        $text = Pdf::getText($file->getPathname());
+
+        // TODO: Process \$text to create transactions or other records.
+
+        // Store the uploaded file for reference.
+        $file->store('statements');
+
+        return back()->with('status', 'Statement uploaded');
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
         "inertiajs/inertia-laravel": "^2.0",
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.10.1",
-        "tightenco/ziggy": "^2.4",
-        "spatie/pdf-to-text": "^1.0"
+        "spatie/pdf-to-text": "^1.54",
+        "tightenco/ziggy": "^2.4"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "inertiajs/inertia-laravel": "^2.0",
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.10.1",
-        "tightenco/ziggy": "^2.4"
+        "tightenco/ziggy": "^2.4",
+        "spatie/pdf-to-text": "^1.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b69c7a6419170e02b2a078b6c41fceee",
+    "content-hash": "b7a3220308b39dd623c8f967d2a32129",
     "packages": [
         {
             "name": "brick/math",
@@ -3339,6 +3339,64 @@
                 "source": "https://github.com/ramsey/uuid/tree/4.9.0"
             },
             "time": "2025-06-25T14:20:11+00:00"
+        },
+        {
+            "name": "spatie/pdf-to-text",
+            "version": "1.54.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/pdf-to-text.git",
+                "reference": "ad2a792c7e1e68f1bc9b038dc73cdcf760595fbb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/pdf-to-text/zipball/ad2a792c7e1e68f1bc9b038dc73cdcf760595fbb",
+                "reference": "ad2a792c7e1e68f1bc9b038dc73cdcf760595fbb",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0",
+                "symfony/process": "^4.0|^5.0|^6.0|^7.0"
+            },
+            "require-dev": {
+                "pestphp/pest-plugin-laravel": "^1.3",
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\PdfToText\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Extract text from a pdf",
+            "homepage": "https://github.com/spatie/pdf-to-text",
+            "keywords": [
+                "pdf-to-text",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/pdf-to-text/issues",
+                "source": "https://github.com/spatie/pdf-to-text/tree/1.54.1"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                }
+            ],
+            "time": "2025-06-13T15:23:19+00:00"
         },
         {
             "name": "symfony/clock",

--- a/resources/js/components/AppHeader.vue
+++ b/resources/js/components/AppHeader.vue
@@ -12,7 +12,7 @@ import UserMenuContent from '@/components/UserMenuContent.vue';
 import { getInitials } from '@/composables/useInitials';
 import type { BreadcrumbItem, NavItem } from '@/types';
 import { Link, usePage } from '@inertiajs/vue3';
-import { LayoutGrid, Menu, Search, FileText, Bot } from 'lucide-vue-next';
+import { LayoutGrid, Menu, Search, FileText, Bot, UploadCloud } from 'lucide-vue-next';
 import { computed } from 'vue';
 
 interface Props {
@@ -42,6 +42,11 @@ const mainNavItems: NavItem[] = [
         title: 'Transactions',
         href: '/transactions',
         icon: FileText,
+    },
+    {
+        title: 'Upload Statement',
+        href: '/statements/upload',
+        icon: UploadCloud,
     },
     {
         title: 'AI Advisor',

--- a/resources/js/components/AppSidebar.vue
+++ b/resources/js/components/AppSidebar.vue
@@ -5,7 +5,7 @@ import NavUser from '@/components/NavUser.vue';
 import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
 import { type NavItem } from '@/types';
 import { Link } from '@inertiajs/vue3';
-import { LayoutGrid, FileText, Bot } from 'lucide-vue-next';
+import { LayoutGrid, FileText, Bot, UploadCloud } from 'lucide-vue-next';
 import AppLogo from './AppLogo.vue';
 
 const mainNavItems: NavItem[] = [
@@ -18,6 +18,11 @@ const mainNavItems: NavItem[] = [
         title: 'Transactions',
         href: '/transactions',
         icon: FileText,
+    },
+    {
+        title: 'Upload Statement',
+        href: '/statements/upload',
+        icon: UploadCloud,
     },
     {
         title: 'AI Advisor',

--- a/resources/js/pages/UploadStatement.vue
+++ b/resources/js/pages/UploadStatement.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import AppLayout from '@/layouts/AppLayout.vue'
+import { Head, useForm } from '@inertiajs/vue3'
+import { Button } from '@/components/ui/button'
+import type { BreadcrumbItem } from '@/types'
+
+const breadcrumbs: BreadcrumbItem[] = [
+  { title: 'Upload Statement', href: '/statements/upload' },
+]
+
+const form = useForm({
+  statement: null as File | null,
+})
+
+const submit = () => {
+  form.post(route('statements.store'), {
+    forceFormData: true,
+  })
+}
+</script>
+
+<template>
+  <AppLayout :breadcrumbs="breadcrumbs">
+    <Head title="Upload Statement" />
+    <form @submit.prevent="submit" class="p-4 space-y-4">
+      <input
+        id="statement"
+        type="file"
+        name="statement"
+        accept="application/pdf"
+        @change="form.statement = $event.target.files[0]"
+        class="file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+      />
+      <Button type="submit" :disabled="form.processing">Upload</Button>
+    </form>
+  </AppLayout>
+</template>

--- a/resources/js/pages/UploadStatement.vue
+++ b/resources/js/pages/UploadStatement.vue
@@ -1,37 +1,70 @@
 <script setup lang="ts">
 import AppLayout from '@/layouts/AppLayout.vue'
 import { Head, useForm } from '@inertiajs/vue3'
+
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import { Label } from '@/components/ui/label'
+import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
+
+import { FileUp } from 'lucide-vue-next'
+
 import type { BreadcrumbItem } from '@/types'
 
 const breadcrumbs: BreadcrumbItem[] = [
-  { title: 'Upload Statement', href: '/statements/upload' },
+    { title: 'Upload Statement', href: '/statements/upload' },
 ]
 
-const form = useForm({
-  statement: null as File | null,
+const form = useForm<{ statement: File | null }>({
+    statement: null,
 })
 
 const submit = () => {
-  form.post(route('statements.store'), {
-    forceFormData: true,
-  })
+    form.post(route('statements.store'), { forceFormData: true })
 }
 </script>
 
 <template>
-  <AppLayout :breadcrumbs="breadcrumbs">
-    <Head title="Upload Statement" />
-    <form @submit.prevent="submit" class="p-4 space-y-4">
-      <input
-        id="statement"
-        type="file"
-        name="statement"
-        accept="application/pdf"
-        @change="form.statement = $event.target.files[0]"
-        class="file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
-      />
-      <Button type="submit" :disabled="form.processing">Upload</Button>
-    </form>
-  </AppLayout>
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <Head title="Upload Statement" />
+
+        <Card class="mx-auto mt-8 max-w-lg shadow-lg">
+            <CardHeader class="flex items-center space-x-2">
+                <FileUp class="h-5 w-5 shrink-0" />
+                <CardTitle class="text-lg font-medium">Upload your statement</CardTitle>
+            </CardHeader>
+
+            <CardContent>
+                <form @submit.prevent="submit" class="space-y-4">
+                    <div class="grid w-full items-center gap-2">
+                        <Label for="statement">Statement file</Label>
+
+                        <!-- shadcn Input handles focus / ring styling for us -->
+                        <Input
+                            id="statement"
+                            type="file"
+                            name="statement"
+                            accept="application/pdf,text/csv"
+                            @change="form.statement = $event.target.files[0]"
+                            :disabled="form.processing"
+                        />
+
+                        <!-- helper text -->
+                        <p class="text-xs text-muted-foreground">
+                            Accepted formats: PDF or CSV • Max 5 MB
+                        </p>
+
+                        <!-- validation errors (Inertia automatically injects them) -->
+                        <p v-if="form.errors.statement" class="text-sm text-destructive">
+                            {{ form.errors.statement }}
+                        </p>
+                    </div>
+
+                    <Button type="submit" class="w-full" :disabled="form.processing">
+                        {{ form.processing ? 'Uploading…' : 'Upload' }}
+                    </Button>
+                </form>
+            </CardContent>
+        </Card>
+    </AppLayout>
 </template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
+use App\Http\Controllers\StatementController;
 
 Route::get('/', function () {
     return Inertia::render('Welcome');
@@ -15,6 +16,9 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('transactions', function () {
         return Inertia::render('Transactions');
     })->name('transactions');
+
+    Route::get('statements/upload', [StatementController::class, 'create'])->name('statements.create');
+    Route::post('statements/upload', [StatementController::class, 'store'])->name('statements.store');
 
     Route::get('advisor', function () {
         return Inertia::render('AIAdvisor');


### PR DESCRIPTION
## Summary
- add `StatementController` with PDF upload logic using spatie/pdf-to-text
- expose upload routes for GET/POST
- add `UploadStatement` page
- extend header and sidebar navigation
- declare spatie/pdf-to-text in composer.json

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-config-prettier')*
- `composer test` *(fails: vendor autoload not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884df3fbcbc8320963d58705ec2ae12