### PR TITLE
Update occurred_at column type

### DIFF
--- a/database/migrations/2025_07_27_020000_modify_occured_at_column_in_transactions_table.php
+++ b/database/migrations/2025_07_27_020000_modify_occured_at_column_in_transactions_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('transactions', function (Blueprint $table) {
+            $table->date('occurred_at')->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('transactions', function (Blueprint $table) {
+            $table->dateTime('occurred_at')->change();
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- add migration to change `occurred_at` in `transactions` to a `date` column

## Testing
- `composer test` *(fails: cannot find vendor autoload)*

------
https://chatgpt.com/codex/tasks/task_e_6885e78c33188320b0157079a3547153